### PR TITLE
Support custom headers

### DIFF
--- a/cmd/polyman/main.go
+++ b/cmd/polyman/main.go
@@ -21,7 +21,6 @@ var (
 )
 
 func CallHandler(w http.ResponseWriter, r *http.Request) {
-	// Usage with Polyglot 2.0 : java -jar polyglot.jar [options] [command] [command options]
 	service := mux.Vars(r)["service"]
 	method := mux.Vars(r)["method"]
 	methodFlag := "--full_method=" + service + "/" + method


### PR DESCRIPTION
With Polyglot 2.0.0, there has been some changes in the invocations for underlying Polyglot API.
-> Usage is now : java -jar polyglot.jar [options] [command] [command options]
Options:
    --config_set_path
      Overrides the default location for the config file 'config.pb.json'
    --config_name
      Overrides the name of the configuration to use from the set (default: 
      use the first one)
    --proto_discovery_root
      Root directory to scan for proto files
    --add_protoc_includes
      Adds to the protoc include paths
    --output_file_path
      File to use for output when destination is set to write to file
    --use_reflection
      Try to use reflection first to resolve protos (default: true)
    --help

  Commands:
    call      Make a GRPC call to an endpoint
      Usage: call [options]
        Options:
        * --full_method
            Full name of the method to call: 
            <some.package.Service/doSomething> 
        * --endpoint
            Service endpoint to call: <host>:<port>
          --deadline_ms
            How long to wait for a call to complete (see gRPC doc)
          --metadata
            Metadata for this call in the form of key-value pairs: 
            k1:v1,k2:v2,... 
          --use_tls
            Whether to use a secure TLS connection (see gRPC doc)
          --tls_ca_cert_path
            File to use as a root certificate for calls using TLS
          --tls_client_cert_path
            If set, will use client certs for calls using TLS
          --tls_client_key_path
            <path>
          --tls_client_override_authority
            <host>

    list_services      List all known services defined in the proto files
      Usage: list_services [options]
        Options:
          --method_filter
            Filters service methods to those containing this string
          --service_filter
            Filters service names containing this string
          --with_message
            If true, then the message specification for the method is rendered

Added support in Polyman for the above  change in invocation

-> Support additional header "metadata" for custom header info for the "Call" command in Polyglot
